### PR TITLE
Clean text to avoid XSS when katex fails to render

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,6 +152,11 @@ function math_block(state, start, end, silent){
     return true;
 }
 
+function cleanString(html){
+     html = html.replace(/[^\w\s]/gi, '')
+     return html;
+}
+
 module.exports = function math_plugin(md, options) {
     // Default options
 
@@ -165,7 +170,7 @@ module.exports = function math_plugin(md, options) {
         }
         catch(error){
             if(options.throwOnError){ console.log(error); }
-            return latex;
+            return cleanString(latex);
         }
     };
 
@@ -180,7 +185,7 @@ module.exports = function math_plugin(md, options) {
         }
         catch(error){
             if(options.throwOnError){ console.log(error); }
-            return latex;
+            return cleanString(latex);
         }
     }
 


### PR DESCRIPTION
### 📊 Metadata *

Avoid XSS when katex fails to render

#### Bounty URL: https://www.huntr.dev/bounties/1-maven-markdown-it-katex

### ⚙️ Description *

Clean string before showing to user

### 💻 Technical Description *

Removed special chars using regexp

### 🐛 Proof of Concept (PoC) *

![Captura de pantalla de 2020-08-21 16-21-58](https://user-images.githubusercontent.com/7505980/90895381-bfdc3480-e3ca-11ea-940f-b3713f26b958.png)

### 🔥 Proof of Fix (PoF) *

![Captura de pantalla de 2020-08-21 16-21-26](https://user-images.githubusercontent.com/7505980/90895402-c7034280-e3ca-11ea-9cca-9e11d6752dff.png)

### 👍 User Acceptance Testing (UAT)

Original operation unafected

![Captura de pantalla de 2020-08-21 16-24-56](https://user-images.githubusercontent.com/7505980/90895471-e306e400-e3ca-11ea-91ed-b3c244bf7541.png)
